### PR TITLE
allow sas disks to be detected

### DIFF
--- a/metal-md-disks.sh
+++ b/metal-md-disks.sh
@@ -11,7 +11,7 @@ type metal_die > /dev/null 2>&1 || . /lib/metal-md-lib.sh
 [ -z "${metal_server:-}" ] && exit 0
 
 # DISKS or RETRY
-md_disks="$(lsblk -l -o SIZE,NAME,TYPE,TRAN | grep -E '(sata|nvme)' | sort -h | awk '{print $2}' | head -n ${metal_disks} | tr '\n' ' ')"
+md_disks="$(lsblk -l -o SIZE,NAME,TYPE,TRAN | grep -E '(sata|nvme|sas)' | sort -h | awk '{print $2}' | head -n ${metal_disks} | tr '\n' ' ')"
 [ -z "${md_disks}" ] && exit 1
 
 # PAVE & GO-AROUND/RETRY

--- a/metal-md-lib.sh
+++ b/metal-md-lib.sh
@@ -271,7 +271,7 @@ pave() {
     local doomed_vgs='vg_name=~ceph*'
 
     # Select the span of devices we care about; RAID, SATA, and NVME devices/handles.
-    doomed_disks=$(lsblk -l -o SIZE,NAME,TYPE,TRAN | grep -E '(raid|sata|nvme)' | sort -u | awk '{print "/dev/"$2}' | tr '\n' ' ')
+    doomed_disks=$(lsblk -l -o SIZE,NAME,TYPE,TRAN | grep -E '(raid|sata|nvme|sas)' | sort -u | awk '{print "/dev/"$2}' | tr '\n' ' ')
     [ -z "$doomed_disks" ] && echo 0 > /tmp/metalpave.done && return 0
 
     info nothing can be done to stop this except one one thing...


### PR DESCRIPTION
This is related to #1.  We've been testing this on the alvarez system, however, it's worth noting I'm still chasing an issue with ceph choosing too-few OSDs on one server, but I don't think it's related to this change.