### PR TITLE
WIP MTL-1654 Support OverlayFS Rollbacks

### DIFF
--- a/90metalmdsquash/metal-md-lib.sh
+++ b/90metalmdsquash/metal-md-lib.sh
@@ -241,6 +241,7 @@ add_overlayfs() {
     [ -f /tmp/metalovalimg.done ] && return
     [ -f /tmp/metalovaldisk.done ] || make_raid_overlay
     local mpoint=/metal/ovaldisk
+    local overlayfs="${mpoint}/${live_dir}/${squashfs_file}-overlayFS"
     mkdir -pv ${mpoint}
     if ! mount -v -n -t xfs /dev/md/ROOT "$mpoint"; then
 
@@ -252,10 +253,12 @@ add_overlayfs() {
     # Create OverlayFS directories for dmsquash-live
     # See source-code for details: https://github.com/dracutdevs/dracut/blob/09a1e5afd2eaa7f8e9f3beaf8a48283357e7fea0/modules.d/90dmsquash-live/dmsquash-live-root.sh#L168-L169
     # Requires two directories; ovlwork, and overlay-$FSLABEL-$UUID (where FSLABEL and UUID are of the partition containing the squashFS image).
+    mkdir -m 0755 -p \
+        "${overlayfs}" \
+        "${overlayfs}/../ovlwork"
     [ -z "${metal_overlayfs_id}" ] && metal_overlayfs_id="$(_overlayFS_path_spec)"
-    mkdir -v -m 0755 -p \
-        "${mpoint}/${live_dir}/${metal_overlayfs_id}" \
-        "${mpoint}/${live_dir}/${metal_overlayfs_id}/../ovlwork"
+
+    ln -snf "${squashfs_file}-overlayFS" ${metal_overlayfs_id} && mv ${metal_overlayfs_id} ${mpoint}/${live_dir}/
     echo 1 > /tmp/metalovalimg.done && info 'OverlayFS is ready ...'
     umount -v ${mpoint}
 }


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1654

##### Issue Type
<!--- Delete un-needed bullets -->

- RFE Pull Request

This enables rollbacks to a previous SquashFS and its matching OverlayFS for NCNs. This also facilitates upgrades to a new SquashFS but removing the need to wipe the node, or reset the OverlayFS. The changes here create a symbolic link that dracut-dmsquash-live will read, this symbolic link will point to a directory. The directory that the symbolic link points to will be named after the `rd.live.squashimg` kernel argument, which is changed whenever we have a new squashFS image. Thus, changing that argument will create a new, coupled overlayFS for that squashFS image or in the case of an existing squashFS image it'll use that squashFS's old OverlayFS.

Specifically, if a new squashFS image named `foo.squashfs` is specified by `rd.live.squashimg=foo.squashfs` then a new OverlayFS will be created. For a rollback, 

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (x) (if yes, please include results or a description of the test)
 

#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
Yes.

#### Risks and Mitigations
 
What is less risky, or more risky now - or if your mod fails is there a new risk?

This is low-risk, as the same deployment and reboot behavior will be observed by users. This PR adds features without hindering current behavior.