### PR TITLE
MTL-1811 Incorrect FSopt Fails to Mount Partitions in SLES15SP4

### DIFF
--- a/90metalmdsquash/metal-lib.sh
+++ b/90metalmdsquash/metal-lib.sh
@@ -87,7 +87,7 @@ export metal_fstab=/etc/fstab.metal
 # constant: metal_fsopts_xfs
 #
 # COMMA-DELIMITED-LIST of fsopts for XFS
-export metal_fsopts_xfs=noatime,largeio,inode64,swalloc,allocsize=13107
+export metal_fsopts_xfs=noatime,largeio,inode64,swalloc,allocsize=131072k
 
 ##############################################################################
 # constant: metal_disk_small


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1811

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

`allocsize=13107` is invalid and has been ignored (perhaps discarded) by xfsprogs in SLES15SP2 and SLES15SP3, in SLES15SP4 this value prevents XFS from mounting.

SP3:
```bash
ncn-w003:~ # rpm -q --whatprovides /sbin/mkfs.xfs
xfsprogs-4.15.0-4.52.1.x86_64
```
SP4:
```bash
ncn-w001:~ # rpm -q --whatprovides /sbin/mkfs.xfs
xfsprogs-5.13.0-150400.1.9.x86_64
```

Somehow between xfsprogs-4.15 and 5.13 the handling of how `allocsize` is enforced has been made more strict. It is not known if our bad value was being honored at all in previous versions of xfsprogs, but we know in our current xfsprogs for SP4 that it causes a fatal error.

This PR changes the value to 131072, a valid value which is 2^17.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
What is less risky, or more risky now - or if your mod fails is there a new risk?
