### PR TITLE
MTL-1819 Resolve Failed Wait Condition

### DIFF
--- a/90metalmdsquash/metal-lib.sh
+++ b/90metalmdsquash/metal-lib.sh
@@ -70,6 +70,15 @@ fi
 _load_dracut_dep
 
 ##############################################################################
+# constant: METAL_DONE_FILE_PAVED
+#
+# This file path present a file that the wipe function creates when it is 
+# invoked. The existence of the file implies the wipe code as been invoked,
+# the contents of the file can be interpretted to determine what the wipe
+# function actually did (see func metal_paved).
+export METAL_DONE_FILE_PAVED='/tmp/metalpave.done'
+
+##############################################################################
 # constant: metal_transports
 #
 # PIPE-DELIMITED-LIST of Transports to acknowledge from `lsblk` queries; these transports are 
@@ -243,8 +252,8 @@ metal_resolve_disk() {
 #
 metal_paved() {
     local rc
-    if [ -f /tmp/metalpave.done ]; then
-        rc="$(cat /tmp/metalpave.done)"
+    if [ -f "$METAL_DONE_FILE_PAVED" ]; then
+        rc="$(cat "$METAL_DONE_FILE_PAVED")"
         case "$rc" in
             1)
                 # 1 indicates the pave function ran and the disks were wiped.
@@ -258,12 +267,12 @@ metal_paved() {
                 ;;
             *)
                 echo >&2 "Wipe has emitted an unknown error code: $rc"
-                return 1
+                return 2
                 ;;
         esac
     else
-        # No file indicates the wipe function hasn't been called.
-        echo >&2 'Wipe pending or cancelled.'
+        # No file indicates the wipe function hasn't been called yet.
+        echo >&2 "No sign of wipe function being called (yet). $METAL_DONE_FILE_PAVED was not found"
         return 1
     fi
 }

--- a/90metalmdsquash/metal-md-disks.sh
+++ b/90metalmdsquash/metal-md-disks.sh
@@ -39,8 +39,8 @@ disks_exist || exit 1
 # Now that disks exist it's worthwhile to load the libraries.
 command -v pave > /dev/null 2>&1 || . /lib/metal-md-lib.sh
 
-# PAVE & GO-AROUND/RETRY
-[ ! -f /tmp/metalpave.done ] && [ "${metal_nowipe:-0}" != 1 ] && pave
+# Wipe; this returns early if a wipe was already done.
+pave
 
 # Check for existing RAIDs
 /sbin/metal-md-scan

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ storing persistent overlays.
       * [`metal.disks`](README.md#metaldisks)
       * [`metal.md-level`](README.md#metalmd-level)
       * [`metal.no-wipe`](README.md#metalno-wipe)
+      * [`metal.wipe-delay`](README.md#metalwipe-delay)
       * [`metal.ipv4`](README.md#metalipv4)
       * [`metal.sqfs-md-size`](README.md#metalsqfs-md-size)
       * [`metal.oval-md-size`](README.md#metaloval-md-size)
@@ -114,19 +115,19 @@ These drivers schemes are all defined by the rule generator, [`metal-genrules.sh
 
 <a name="metaldebug"></a>
 ##### `metal.debug`
-> - `default: 0`
+> - `Default: 0`
 > 
 > Set `metal.debug=1` to enable debug output from only metal modules. This will verbosely print the creation of the RAIDs and fetching of the squashFS image. **This effectively runs all dracut-metal code with `set -x`**, while leaving the rest of dracut to its own debug level.
 
 <a name="metaldisks"></a>
 ##### `metal.disks`
-> - `default: 2`
+> - `Default: 2`
 > 
 > Specify the number of disks to use in the local RAID (see [`metal.md-level`](README.md#metalmd-level) for changing the RAID type).
 
 <a name="metalmd-level"></a>
 ##### `metal.md-level`
-> - `default: mirror`
+> - `Default: mirror`
 > 
 > Change the level passed to mdadm for RAID creation, possible values are any value it takes. 
 > Milaege varies, buyer beware this could dig a hole deeper.
@@ -136,14 +137,22 @@ These drivers schemes are all defined by the rule generator, [`metal-genrules.sh
 
 <a name="metalno-wipe"></a>
 ##### `metal.no-wipe`
-> - `default: 0`
+> - `Default: 0`
 > 
 > If this is set to `metal.no-wipe=1`, then all destructive behavior is disabled. The metal modules will either use what they find or make 0 changes during boots. This is insurance, it should not be required. This is helpful for development, or for admins tracking old and new nodes.
 
 
+<a name="metalwipe-delay"></a>
+##### `metal.wipe-delay`
+> - `Default: 5`
+> - `Unit: Seconds`
+>
+> The number of seconds that the wipe function will wait to allow an administrator to cancel it (by powering the node off). See the source code in [`metal-md-lib.sh`](./90metalmdsquash/metal-md-lib.sh) for minimum and maximum values.
+
+
 <a name="metalipv4"></a>
 ##### `metal.ipv4`
-> - `default: 1`
+> - `Default: 1`
 >
 > By default, metal-dracut will use IPv4 to resolve the deployment server for the initial call-to-home and when downloading artifacts regardless if IPv6 networking is present in the environment. To disable this constraint, simply set `metal.ipv4=0` in the cmdline. Setting this to `0` will enable all `ping` and `curl` calls for calling-home and downloading artifacts to use **either** IPv6 or IPv4 on their own accord (e.g. if IPv6 exists, then `ping` and `curl` will prefer to use it by default). Presumably if IPv6 is desired and exists, then IPv6 DHCP/DNS and general TCP/IP connectivity is working.
 > Lastly, if IPv6 does not exist then toggling this value to `0` has no effect.
@@ -151,8 +160,8 @@ These drivers schemes are all defined by the rule generator, [`metal-genrules.sh
 
 <a name="metalsqfs-md-size"></a>
 ##### `metal.sqfs-md-size`
-> - default: `25`
-> - Unit: Gigabytes
+> - `Default: 25`
+> - `Unit: Gigabytes`
 > 
 > Set the size for the new SQFS partition.
 > Buyer beware this does not resize, this applies for new partitions.
@@ -160,8 +169,8 @@ These drivers schemes are all defined by the rule generator, [`metal-genrules.sh
 
 <a name="metaloval-md-size"></a>
 ##### `metal.oval-md-size`
-> - default: `150`
-> - Unit: Gigabytes
+> - `Default: 150`
+> - `Unit: Gigabytes`
 > 
 > Set the size for the new SQFS partition.
 > Buyer beware this does not resize, this applies for new partitions.
@@ -169,8 +178,8 @@ These drivers schemes are all defined by the rule generator, [`metal-genrules.sh
 
 <a name="metalaux-md-size"></a>
 ##### `metal.aux-md-size`
-> - default: `150`
-> - Unit: Gigabytes
+> - `Default: 150`
+> - `Unit: Gigabytes`
 >
 > Set the size for the new SQFS partition.
 > Buyer beware this does not resize, this applies for new partitions.
@@ -184,13 +193,13 @@ reference: [dracut dmsquashlive cmdline](1)
 
 <a name="rdlivedir"></a>
 ##### `rd.live.dir`
-> - `default: LiveOS`
+> - `Default: LiveOS`
 > 
 > Name of the directory store and load the artifacts from. Changing this value will affect metal and native-dracut.
 
 <a name="root"></a>
 ##### `root`
-> - `default: live:LABEL=SQFSRAID`
+> - `Default: live:LABEL=SQFSRAID`
 > 
 > Specify the FSlabel of the block device to use for the SQFS storage. This could be an existing RAID or non-RAIDed device.
 > If a label is not found in `/dev/disk/by-label/*`, then the os-disks are paved with a new mirror array.
@@ -198,7 +207,7 @@ reference: [dracut dmsquashlive cmdline](1)
 
 <a name="rdliveoverlay"></a>
 ##### `rd.live.overlay`
-> - `default: LABEL=ROOTRAID`
+> - `Default: LABEL=ROOTRAID`
 > 
 > Specify the FSlabel of the block device to use for persistent storage.
 > If a label is not found in `/dev/disk/by-label/*`, then the os-disks are paved.
@@ -206,13 +215,13 @@ reference: [dracut dmsquashlive cmdline](1)
 
 <a name="rdliveoverlay.readonly"></a>
 ##### `rd.live.overlay.readonly`
-> - `default: 0`
+> - `Default: 0`
 > 
 > Make the persistent overlayFS read-only.
 
 <a name="rdliveoverlayreset"></a>
 ##### `rd.live.overlay.reset`
-> - `default: 0`
+> - `Default: 0`
 > 
 > Reset the persistent overlayFS, regardless if it is read-only.
 > On the **next** boot the overlayFS will clear itself, it will continue to clear itself every
@@ -221,13 +230,13 @@ reference: [dracut dmsquashlive cmdline](1)
 
 <a name="rdliveoverlaysize"></a>
 ##### `rd.live.overlay.size`
-> - `default: 204800`
+> - `Default: 204800`
 > 
 > Specify the size of the overlay in MB.
 
 <a name="rdlivesquashimg"></a>
 ##### `rd.live.squashimg`
-> - `default: filesystem.squashfs`
+> - `Default: filesystem.squashfs`
 > 
 > Specify the filename to refer to download.
 
@@ -238,7 +247,7 @@ notereference: [dracut standard cmdline](2)
 
 <a name="rootfallback"></a>
 ##### `rootfallback`
-> - `default: LABEL=BOOTRAID`
+> - `Default: LABEL=BOOTRAID`
 > 
 > This the label for the partition to be used for a fallback bootloader.
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1819

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Currently, netboots using `metal.no-wipe=1` may or may not succeed. This PR fixes a race condition where our k8s-master and k8s-worker modules never exit while waiting for the wipe function to end.

`metal-md-disks.sh` had an oversight, when checking metal.no-wipe=1 the `/tmp/metalpave.done` file was never created. This prevented the `metal_paved` function from correctly reporting whether the pave had actually finished or had been skipped. This failure causes the dependent modules running on k8s-masters and k8s-workers to never exit properly when `metal.no-wipe=1` was set on netboots.

Lastly there are a few minor tweaks in this commit:
- This also fixes the pave function's 5-second timer which was actually only giving the user 4 seconds due to using `-gt` instead of `-ge`.
- Additionally this fixes the log truncation in the pave function, the ending line stating 'pave done' was truncating the log-file.
- Adds a `metal.wipe-delay` kernel argument for changing the delay-time from 5 seconds to anything between 2 and 60 seconds.
- Lastly this moves `/tmp/metalpave.done` into a global variable set in `metal-lib.sh`, making it less error prone to typo mistakes.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
This removes risk of dependent dracut modules from running indefinitely, causing the boot to stall.