### PR TITLE
MTL-1839 Invoke the RAID Setup in KDUMP

### DIFF
--- a/90metalmdsquash/metal-genrules.sh
+++ b/90metalmdsquash/metal-genrules.sh
@@ -25,8 +25,19 @@
 # metal-genrules.sh
 [ "${metal_debug:-0}" = 0 ] || set -x
 
-command -v metal_die > /dev/null 2>&1 || . /lib/metal-lib.sh
+command -v getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+case "$(getarg root)" in 
+    kdump)
+        /sbin/initqueue --settled /sbin/metal-md-scan
+        
+        # Ensure nothing else in this script is invoked in this case.
+        exit 0
+        ;;
+esac
+
 command -v wait_for_dev > /dev/null 2>&1 || . /lib/dracut-lib.sh
+command -v metal_die > /dev/null 2>&1 || . /lib/metal-lib.sh
 
 # Load and execute with desired URL driver.
 case "${metal_server:-}" in

--- a/90metalmdsquash/metal-md-lib.sh
+++ b/90metalmdsquash/metal-md-lib.sh
@@ -110,10 +110,6 @@ case "$root" in
         export sqfs_drive_scheme=${sqfs_drive_spec%%=*}
         export sqfs_drive_authority=${sqfs_drive_spec#*=}
         ;;
-    kdump)
-        # TODO: Remove this case; kdump's initrd should not have metal.server set or it should remove this module.
-        info "kdump detected. continuing..."
-        ;;
     '')
         warn "No root; root needed - the system will likely fail to boot."
         # do not fail, allow dracut to handle everything in case an operator/admin is doing something.
@@ -306,11 +302,6 @@ fetch_sqfs() {
 ## SquashFS
 # Add a local file to squashFS storage.
 add_sqfs() {
-    # TODO: this could maybe move into metal-genrules.sh, preventing any call under kdump.
-    if [ $root = "kdump" ]; then
-        echo "skipping metal-phone-home for kdump..."
-        return 0
-    fi
 
     local sqfs_store=/metal/squashfs
     local dhcp_retry=$(getargnum 1 1 1000000000 rd.net.dhcp.retry=)


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1839
- Relates to: CASMTRIAGE-3591

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This moves kdump handling to a single place, and in the event of a kernel-dump our module will invoke the RAID helper script and exit.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
