### PR TITLE
CODEOWNERS isn't adding reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,1 @@
-# Global
 *               @Cray-HPE/metal
-
-# Dracut Module Creator
-90metalmdsquash/   @rustydb
-
-# Publishing
-gh-pages        @jacobsalmela


### PR DESCRIPTION
`CODEOWNERS` is too complicated, and is preventing the repository from auto-adding reviewers.