### PR TITLE
MTL-1852 Add partprobe

### DIFF
--- a/90metalmdsquash/module-setup.sh
+++ b/90metalmdsquash/module-setup.sh
@@ -44,7 +44,7 @@ installkernel() {
 
 # called by dracut
 install() {
-    inst_multiple cut curl diff efibootmgr head lsblk mkfs.ext4 mkfs.vfat mkfs.xfs parted seq sort tail wc vgscan xfs_admin
+    inst_multiple cut curl diff efibootmgr head lsblk mkfs.ext4 mkfs.vfat mkfs.xfs parted partprobe seq sort tail wc vgscan xfs_admin
     # install our callables
     inst_simple "$moddir/mdadm.conf" "/etc/mdadm.conf"
     inst_simple "$moddir/metal-md-lib.sh" "/lib/metal-md-lib.sh"


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1852

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Installs `partprobe` into the initramFS.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
This module is only installing `partprobe`, is isn't using it. This module uses a function called `_trip_udev`, I theorize this has avoided `mkfs` race conditions.