### PR TITLE
CASMINST-5103 Better LVM logging

### DIFF
--- a/90metalmdsquash/metal-md-lib.sh
+++ b/90metalmdsquash/metal-md-lib.sh
@@ -377,17 +377,18 @@ pave() {
     cat /proc/mdstat >>$log 2>&1
     if [ "$metal_nowipe" != 0 ]; then
         echo "${FUNCNAME[0]} skipped: metal.no-wipe=${metal_nowipe}" >>$log
-        warn 'local storage device wipe [ safeguard ENABLED  ]'
+        warn 'local storage device wipe [ safeguard: ENABLED  ]'
         warn 'local storage devices will not be wiped.'
         echo 0 > "$METAL_DONE_FILE_PAVED" && return 0
     else
-        warn 'local storage device wipe [ safeguard DISABLED ]'
+        warn 'local storage device wipe [ safeguard: DISABLED ]'
     fi
-    warn 'local storage device wipe commencing (USB devices are ignored)...'
+    warn 'local storage device wipe commencing (USB devices are ignored) ...'
 
     local doomed_disks
     local doomed_ceph_vgs='vg_name=~ceph*'
     local doomed_metal_vgs='vg_name=~metal*'
+    local vgfailure
 
     # Select the span of devices we care about; RAID, and all compatible transports.
     doomed_disks="$(lsblk -l -o SIZE,NAME,TYPE,TRAN | grep -E '(raid|'"$metal_transports"')' | sort -u | awk '{print "/dev/"$2}' | tr '\n' ' ' | sed 's/ *$//')"
@@ -405,9 +406,21 @@ pave() {
 
     # NUKE LVMs
     vgscan >&2 && vgs >&2
+    vgfailure=0
     for volume_group in $doomed_ceph_vgs $doomed_metal_vgs; do
-        warn "removing all volume groups of name [$volume_group]" && vgremove -f --select $volume_group -y >&2 || warn "no $volume_group volumes found"
+        warn "removing all volume groups of name [${volume_group}]" && vgremove -f --select ${volume_group} -y >&2 || warn "no ${volume_group} volumes found"
+        if [ "$(vgs --select $volume_group)" != '' ]; then
+            warn "${volume_group} still exists, this is unexpected. Printing vgs table:"
+            vgs >&2
+            vgfailure=1
+        fi
     done
+    if [ ${vgfailure} -ne 0 ]; then
+        warn 'Failed to remove all volume groups! Try rebooting this node again.'
+        warn "If this persists, try running the manual wipe in the emergency shell and reboot again."
+        warn "After trying the manual wipe, run 'echo b >/proc/sysrq-trigger' to reboot"
+        metal_die "https://github.com/Cray-HPE/docs-csm/blob/main/operations/node_management/Wipe_NCN_Disks.md#basic-wipe"
+    fi
 
     # NUKE BLOCKs
     warn "local storage device wipe targeted devices: [$doomed_disks]"

--- a/90metalmdsquash/metal-md-lib.sh
+++ b/90metalmdsquash/metal-md-lib.sh
@@ -404,9 +404,9 @@ pave() {
     #
 
     # NUKE LVMs
-    vgscan
+    vgscan >&2 && vgs >&2
     for volume_group in $doomed_ceph_vgs $doomed_metal_vgs; do
-        warn "removing all volume groups of name [$volume_group]" && vgremove -f --select $volume_group -y >/dev/null 2>&1 || warn "no $volume_group volumes found"
+        warn "removing all volume groups of name [$volume_group]" && vgremove -f --select $volume_group -y >&2 || warn "no $volume_group volumes found"
     done
 
     # NUKE BLOCKs

--- a/90metalmdsquash/module-setup.sh
+++ b/90metalmdsquash/module-setup.sh
@@ -44,7 +44,7 @@ installkernel() {
 
 # called by dracut
 install() {
-    inst_multiple cut curl diff efibootmgr head lsblk mkfs.ext4 mkfs.vfat mkfs.xfs parted seq sort tail wc vgscan xfs_admin
+    inst_multiple cut curl diff efibootmgr head lsblk mkfs.ext4 mkfs.vfat mkfs.xfs parted seq sort tail wc vgs vgscan xfs_admin
     # install our callables
     inst_simple "$moddir/mdadm.conf" "/etc/mdadm.conf"
     inst_simple "$moddir/metal-md-lib.sh" "/lib/metal-md-lib.sh"


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: CASMINST-5103

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
CASMINST-5103 was difficult to debug because at the moment of failure there was no logging output available. Had the node booted in `rd.debug` or `rd.info` mode there might've been more. However we need to see more during the initial boot, and that boot does not run in `rd.debug` nor `rd.info` mode.

This change adds discovered volume groups and removed items to the
console, which would be very helpful to see if CASMINST-5103 were to occur again.

```bash
[   17.848377] dracut-initqueue[1490]:   Found volume group "metalvg0" using metadata type lvm2
[   17.908682] dracut-initqueue[1491]:   VG       #PV #LV #SN Attr   VSize   VFree
[   17.923919] dracut-initqueue[1491]:   metalvg0   1   3   0 wz--n- 279.14g 149.14g
[   17.944605] dracut-initqueue[1441]: Warning: removing all volume groups of name [vg_name=~ceph*]
[   17.964166] dracut-initqueue[1492]:   Failed to clear hint file.
[   18.028993] dracut-initqueue[1441]: Warning: removing all volume groups of name [vg_name=~metal*]
[   18.048173] dracut-initqueue[1514]:   Failed to clear hint file.
[   18.068130] dracut-initqueue[1514]:   Logical volume "CEPHETC" successfully removed
[   18.084107] dracut-initqueue[1514]:   Logical volume "CEPHVAR" successfully removed
[   18.104005] dracut-initqueue[1514]:   Logical volume "CONTAIN" successfully removed
[   18.120106] dracut-initqueue[1514]:   Volume group "metalvg0" successfully removed
```

Output from a clean boot on a worker node:
```bash
 Warning: local storage device wipe [ safeguard: DISABLED ]
 Warning: local storage device wipe commencing (USB devices are ignored) ...
 Warning: nothing can be done to stop this except one one thing ...
 Warning: ... power this node off within the next [5] seconds to prevent any and all operations ...
   Found volume group "metalvg0" using metadata type lvm2
   VG       #PV #LV #SN Attr   VSize   VFree
   metalvg0   1   1   0 wz--n- 279.14g 79.14g
 Warning: removing all volume groups of name [vg_name=~ceph*]
   Failed to clear hint file.
 Warning: removing all volume groups of name [vg_name=~metal*]
   Failed to clear hint file.
   Logical volume "CRAYS3CACHE" successfully removed
   Volume group "metalvg0" successfully removed
 Warning: local storage device wipe targeted devices: [/dev/sda /dev/md127 /dev/md124 /dev/md125 /dev/sdb /dev/sdc /dev/md126]
 Warning: local storage disk wipe complete
 mdadm: No arrays found in config file
 Found the following disks for the main RAID array (qty. [2]): [sdb sdc]
 mdadm: size set to 487360K
 mdadm: array /dev/md/BOOT started.
 mdadm: size set to 23908352K
 mdadm: array /dev/md/SQFS started.
 mdadm: size set to 146352128K
 mdadm: automatically enabling write-intent bitmap on large array
 mdadm: array /dev/md/ROOT started.
 mdadm: chunk size defaults to 512K
 mdadm: array /dev/md/AUX started.
 umount: /metal/ovaldisk unmounted
 Warning: Failed to ping URI host, pit ... (retry: 1)
 wicked: mgmt0: Request to acquire DHCPv4 lease with UUID 9064f162-98a1-0c00-fd07-000001000000
 wicked: mgmt0: Committed DHCPv4 lease with address 10.1.1.6 (lease time 1200 sec, renew in 600 sec, rebind in 1050 sec)
```

Output from a clean boot on a storage node:
```bash
Warning: local storage device wipe [ safeguard: DISABLED ]
Warning: local storage device wipe commencing (USB devices are ignored) ...
Warning: nothing can be done to stop this except one one thing ...
Warning: ... power this node off within the next [5] seconds to prevent any and all operations ...
  Found volume group "metalvg0" using metadata type lvm2
  Found volume group "ceph-d1846b1b-61f7-4fb2-b003-9dd47dc7775f" using metadata type lvm2
  Found volume group "ceph-8c71fcc4-2589-4bdd-ad2c-7f5f35a8ffdb" using metadata type lvm2
  Found volume group "ceph-55ee50a6-8130-468a-97cc-8c0d0589d2f8" using metadata type lvm2
  Found volume group "ceph-b9b6c6a9-c67a-4721-84d2-a777203c24a1" using metadata type lvm2
  VG                                        #PV #LV #SN Attr   VSize   VFree
  ceph-55ee50a6-8130-468a-97cc-8c0d0589d2f8   1   1   0 wz--n-  <1.75t      0
  ceph-8c71fcc4-2589-4bdd-ad2c-7f5f35a8ffdb   1   1   0 wz--n-  <1.75t      0
  ceph-b9b6c6a9-c67a-4721-84d2-a777203c24a1   1   1   0 wz--n-  <1.75t      0
  ceph-d1846b1b-61f7-4fb2-b003-9dd47dc7775f   1   1   0 wz--n-  <1.75t      0
  metalvg0                                    1   3   0 wz--n- 279.14g 149.14g
Warning: removing all volume groups of name [vg_name=~ceph*]
  Failed to clear hint file.
  Logical volume "osd-block-e3e0491c-c6c7-40a1-8ae0-4092c10e7834" successfully removed
  Volume group "ceph-d1846b1b-61f7-4fb2-b003-9dd47dc7775f" successfully removed
  Logical volume "osd-block-cbfdf774-b6c3-46b3-86e6-ec775fd3c331" successfully removed
  Volume group "ceph-8c71fcc4-2589-4bdd-ad2c-7f5f35a8ffdb" successfully removed
  Logical volume "osd-block-1e8099d5-923a-4cb5-a145-a868cd87eabc" successfully removed
  Volume group "ceph-55ee50a6-8130-468a-97cc-8c0d0589d2f8" successfully removed
  Logical volume "osd-block-1da85385-a2ff-46a3-825d-32ab0d35189f" successfully removed
  Volume group "ceph-b9b6c6a9-c67a-4721-84d2-a777203c24a1" successfully removed
Warning: removing all volume groups of name [vg_name=~metal*]
  Failed to clear hint file.
  Logical volume "CEPHETC" successfully removed
  Logical volume "CEPHVAR" successfully removed
  Logical volume "CONTAIN" successfully removed
  Volume group "metalvg0" successfully removed
Warning: local storage device wipe targeted devices: [/dev/sdb /dev/sdd /dev/sde /dev/sdf /dev/md126 /dev/md124 /dev/md127 /dev/sda /dev/sdc /dev/md125]
Warning: local storage disk wipe complete
mdadm: No arrays found in config file
Found the following disks for the main RAID array (qty. [2]): [sda sdc]
mdadm: size set to 487360K
mdadm: array /dev/md/BOOT started.
mdadm: size set to 23908352K
mdadm: array /dev/md/SQFS started.
mdadm: size set to 146352128K
mdadm: automatically enabling write-intent bitmap on large array
mdadm: array /dev/md/ROOT started.
mdadm: chunk size defaults to 512K
mdadm: array /dev/md/AUX started.
umount: /metal/ovaldisk unmounted
Warning: Failed to ping URI host, pit ... (retry: 1)
wicked: mgmt0: Request to acquire DHCPv4 lease with UUID 9467f162-cfef-0d00-0006-000001000000
wicked: mgmt0: Committed DHCPv4 lease with address 10.1.1.11 (lease time 1200 sec, renew in 600 sec, rebind in 1050 sec)
```
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
