### PR TITLE
MTL-1863 Add `%posttrans`

### DIFF
--- a/dracut-metal-mdsquash.spec
+++ b/dracut-metal-mdsquash.spec
@@ -91,4 +91,11 @@ cp -pvrR ./%{module_name}/* %{buildroot}%{dracut_modules}/%{module_name} | awk '
 
 %preun
 
+%posttrans
+mkinitrd -B
+
+if rpm -q kdump 2>&1 >/dev/null ; then
+    mkdumprd -f
+fi
+
 %changelog


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1863

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Invoke both `mkinitrd` and `mkdumprd`, no need for updating the bootloader.

This will ensure that installing or upgrading this package will entail including this module in the existing initrd.

Currently we do this by hand by invoking the `create-kis-artifacts.sh` script in our NCN builds, but in general this RPM should do this automatically.

```bash
ncn-m002:~ # rpm -Uvh --oldpackage /tmp/dracut-metal-mdsquash-2.1.0~1~gc922514-1.noarch.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:dracut-metal-mdsquash-2.1.0~1~gc9################################# [ 50%]
Cleaning up / removing...
   2:dracut-metal-mdsquash-2.1.0~1~g6d################################# [100%]
Creating initrd: /boot/initrd-5.3.18-150300.59.76-default
dracut: Executing: /usr/bin/dracut --logfile /var/log/YaST2/mkinitrd.log --force /boot/initrd-5.3.18-150300.59.76-default 5.3.18-150300.59.76-default
dracut: dracut module 'modsign' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'btrfs' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'dmraid' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'dmsquash-live-ntfs' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'multipath' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'cifs' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'fcoe' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'fcoe-uefi' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'iscsi' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'nbd' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'nfs' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'nvmf' will not be installed, because command 'nvme' could not be found!
dracut: dracut module 'nvmf' will not be installed, because command 'nvme' could not be found!
bash
systemd
systemd-initrd
i18n
network-legacy
network
kernel-modules
kernel-modules-extra
kernel-network-modules
mdraid
dracut: Skipping udev rule: 64-md-raid.rules
metalmdsquash
nvdimm
metaldmk8s
metalluksetcd
rootfs-block
suse-btrfs
suse-xfs
terminfo
udev-rules
dracut: Skipping udev rule: 40-redhat.rules
dracut: Skipping udev rule: 50-firmware.rules
dracut: Skipping udev rule: 50-udev.rules
dracut: Skipping udev rule: 91-permissions.rules
dracut: Skipping udev rule: 80-drivers-modprobe.rules
biosdevname
dracut-systemd
haveged
usrmount
base
fs-lib
shutdown
suse
suse-initrd
dracut: *** Including modules done ***
dracut: *** Installing kernel module dependencies ***
dracut: *** Installing kernel module dependencies done ***
dracut: *** Resolving executable dependencies ***
dracut: *** Resolving executable dependencies done ***
dracut: *** Hardlinking files ***
hardlink: /var/tmp/dracut.oLRFvY/initramfs/init is on different filesystem than the rest (use -f option to override).
dracut: *** Hardlinking files done ***
dracut: *** Stripping files ***
dracut: *** Stripping files done ***
dracut: *** Generating early-microcode cpio image ***
dracut: *** Constructing GenuineIntel.bin ***
dracut: *** Store current command line parameters ***
dracut: Stored kernel commandline:
dracut: rd.driver.pre=raid1
dracut:  rd.md.uuid=d1c3d9db:b5b2c067:de5a0d87:65e6ca3b
dracut:  root=LABEL=ROOTRAID rootfstype=xfs rootflags=defaults
dracut: ro
dracut: *** Creating image file '/boot/initrd-5.3.18-150300.59.76-default' ***
dracut: *** Creating initramfs image file '/boot/initrd-5.3.18-150300.59.76-default' done ***
Did not refresh the bootloader. You might need to refresh it manually.
Regenerating kdump initrd ...
dracut: Executing: /usr/bin/dracut --force --hostonly --omit "plymouth resume usrmount" "--compress=xz -0 --check=crc32" --add kdump /boot/initrd-5.3.18-150300.59.76-default-kdump 5.3.18-150300.59.76-default
dracut: dracut module 'plymouth' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'dmraid' will not be installed, because command 'dmraid' could not be found!
dracut: dracut module 'dmsquash-live-ntfs' will not be installed, because command 'ntfs-3g' could not be found!
dracut: dracut module 'iscsi' will not be installed, because command 'iscsi-iname' could not be found!
dracut: dracut module 'iscsi' will not be installed, because command 'iscsiadm' could not be found!
dracut: dracut module 'iscsi' will not be installed, because command 'iscsid' could not be found!
dracut: dracut module 'nvmf' will not be installed, because command 'nvme' could not be found!
dracut: dracut module 'resume' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'usrmount' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'dmraid' will not be installed, because command 'dmraid' could not be found!
dracut: dracut module 'dmsquash-live-ntfs' will not be installed, because command 'ntfs-3g' could not be found!
dracut: dracut module 'iscsi' will not be installed, because command 'iscsi-iname' could not be found!
dracut: dracut module 'iscsi' will not be installed, because command 'iscsiadm' could not be found!
dracut: dracut module 'iscsi' will not be installed, because command 'iscsid' could not be found!
dracut: dracut module 'nvmf' will not be installed, because command 'nvme' could not be found!
bash
systemd
systemd-initrd
watchdog-modules
i18n
network-legacy
network
drm
kernel-modules
kernel-modules-extra
kernel-network-modules
mdraid
dracut: Skipping udev rule: 64-md-raid.rules
metalmdsquash
nvdimm
metaldmk8s
metalluksetcd
rootfs-block
suse-btrfs
suse-xfs
terminfo
udev-rules
dracut: Skipping udev rule: 40-redhat.rules
dracut: Skipping udev rule: 50-firmware.rules
dracut: Skipping udev rule: 50-udev.rules
dracut: Skipping udev rule: 91-permissions.rules
dracut: Skipping udev rule: 80-drivers-modprobe.rules
biosdevname
dracut-systemd
haveged
base
fs-lib
kdump
shutdown
suse
suse-initrd
dracut: *** Including modules done ***
dracut: *** Installing kernel module dependencies ***
dracut: *** Installing kernel module dependencies done ***
dracut: *** Resolving executable dependencies ***
dracut: *** Resolving executable dependencies done ***
dracut: *** Hardlinking files ***
hardlink: /var/tmp/dracut.JMG99Y/initramfs/init is on different filesystem than the rest (use -f option to override).
dracut: *** Hardlinking files done ***
dracut: *** Stripping files ***
dracut: *** Stripping files done ***
dracut: *** Generating early-microcode cpio image ***
dracut: *** Constructing GenuineIntel.bin ***
dracut: *** Store current command line parameters ***
dracut: Stored kernel commandline:
dracut: rd.driver.pre=raid1
dracut:  rd.md.uuid=d1c3d9db:b5b2c067:de5a0d87:65e6ca3b
dracut:  root=LABEL=ROOTRAID rootfstype=xfs rootflags=defaults
dracut: ro
dracut: *** Creating image file '/boot/initrd-5.3.18-150300.59.76-default-kdump' ***
dracut: *** Creating initramfs image file '/boot/initrd-5.3.18-150300.59.76-default-kdump' done ***
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
