### PR TITLE
MTL-1841 kdump tweak

### DIFF
--- a/90metalmdsquash/metal-kdump.sh
+++ b/90metalmdsquash/metal-kdump.sh
@@ -60,9 +60,9 @@ function prepare {
     kernel_savedir="$(grep -oP 'KDUMP_SAVEDIR="file:///\K\S+[^"]' /run/rootfsbase/etc/sysconfig/kdump)"
 
     if [ ! -d "/run/initramfs/overlayfs/${kernel_savedir}" ]; then
-        mkdir -pv "/run/initramfs/overlayfs/${kernel_savedir}"
-        printf '% -18s\t% -18s\t%s\t%s 0 0\n' "/run/initramfs/overlayfs/${kernel_savedir}" /var/crash none defaults,bind >> $metal_fstab
+        mkdir -pv "/run/initramfs/overlayfs/${LIVE_DIR}/${OVERLAYFS_PATH}/var/crash"
     fi
+    ln -snf "./${LIVE_DIR}/${OVERLAYFS_PATH}/var/crash" "/run/initramfs/overlayfs/${kernel_savedir}"
 
     if [ ! -d "/run/initramfs/overlayfs/${LIVE_DIR}/${OVERLAYFS_PATH}/boot" ]; then
         mkdir -pv "/run/initramfs/overlayfs/${LIVE_DIR}/${OVERLAYFS_PATH}/boot"


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Requires:
- Relates to: MTL-1841

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Removing the bind mount will make the contents of `/var/crash` exist even if `metalfs` fails, which is possible.

```bash
ncn-s004:/run/initramfs/overlayfs # ll
total 4
lrwxrwxrwx 1 root root  67 Jul 29 18:36 boot -> ./LiveOS/overlay-SQFSRAID-fc2a7512-6603-4dbd-9bad-cf08c8b21888/boot
lrwxrwxrwx 1 root root  72 Jul 29 18:56 crash -> ./LiveOS/overlay-SQFSRAID-fc2a7512-6603-4dbd-9bad-cf08c8b21888/var/crash
drwxr-xr-x 4 root root  82 Jul 29 18:36 LiveOS
-rw-r--r-- 1 root root 266 Jul 29 18:36 README.txt
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
