### PR TITLE
MTL-1925 Fix `metal.ipv4`

### DIFF
--- a/90metalmdsquash/parse-metal.sh
+++ b/90metalmdsquash/parse-metal.sh
@@ -34,6 +34,10 @@ metal_overlay=$(getarg rd.live.overlay)
 [ -z "${metal_overlay}" ] && metal_overlay=LABEL=ROOTRAID
 metal_server=$(getarg metal.server=)
 
+# For ${:+} BASH substitution to work, the value must be null or unset (0 != null in BASH)
+getargbool 0 metal.ipv4 -d -y metal_ipv4 && metal_ipv4=1
+[ "${metal_ipv4}" = 0 ] && metal_ipv4=''
+
 export metal_debug
 export metal_disks
 export metal_nowipe


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1925

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
When `metal.ipv4` was set to `1` it was ignored by `ping` and `curl` calls. This change restores the functionality.

Simple example showing how it works, why `0` is changed to `''` and why `1` allows the substitution.
```bash
ncn-w004:~ # [ "${metal_ipv4}" = 0 ] && metal_ipv4=''
+ '[' 0 = 0 ']'
+ metal_ipv4=
ncn-w004:~ # ping ${metal_ipv4:+-4} ncn-w004
+ ping ncn-w004
PING ncn-w004(surtur-ncn-w004.local (::1)) 56 data bytes
64 bytes from surtur-ncn-w004.local (::1): icmp_seq=1 ttl=64 time=0.044 ms
^C
--- ncn-w004 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.044/0.044/0.044/0.000 ms
ncn-w004:~ # ^C
ncn-w004:~ # metal_ipv4=1
+ metal_ipv4=1
ncn-w004:~ # [ "${metal_ipv4}" = 0 ] && metal_ipv4=''
+ '[' 1 = 0 ']'
ncn-w004:~ # ping ${metal_ipv4:+-4} ncn-w004
+ ping -4 ncn-w004
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
