### PR TITLE
MTL-1876 pre-signed URLs

### DIFF
--- a/90metalmdsquash/metal-genrules.sh
+++ b/90metalmdsquash/metal-genrules.sh
@@ -40,18 +40,21 @@ command -v wait_for_dev > /dev/null 2>&1 || . /lib/dracut-lib.sh
 command -v metal_die > /dev/null 2>&1 || . /lib/metal-lib.sh
 
 # Load and execute with desired URL driver.
-case "${metal_server:-}" in
-    file:*|http:*|https:*)
+export metal_uri_scheme=${metal_server%%:*}
+export metal_uri_authority=${metal_server#*:}
+
+case "${metal_uri_scheme:-}" in
+    file|http|https)
         wait_for_dev -n /dev/metal
         /sbin/initqueue --settled /sbin/metal-md-disks
         ;;
-    s3:*)
+    s3)
         metal_die "s3-direct is not implemented, try http/https instead"
         ;;
-    ftp:*)
+    ftp)
         metal_die "insecure ftp is not implemented"
         ;;
-    scp:*|sftp:*)
+    scp|sftp)
         metal_die "credential based transfer (scp and sftp) is not implemented, try http/https instead"
         ;;
     '')
@@ -59,6 +62,6 @@ case "${metal_server:-}" in
         /sbin/initqueue --settled /sbin/metal-md-scan
         ;;
     *)
-        warn "Unknown driver "$metal_server"; metal.server ignored/discarded"
+        warn "Unknown driver $metal_server; metal.server ignored/discarded"
         ;;
 esac


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1876
- Relates to: CASMINST-4849

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This adds support for pre-signed URLs which contain the name of the squashFS file.

A successful test was carried out on drax using a pre-signed URL:

```bash
ncn-w003:~ # cat /proc/cmdline
kernel initrd=initrd biosdevname=1 ifname=hsn1:98:03:9b:7f:bd:20 ip=hsn1:auto6 ifname=hsn0:98:03:9b:7f:bd:1c ip=hsn0:auto6 ifname=lan1:e0:d5:5e:65:91:63 ip=lan1:auto6 ifname=lan0:e0:d5:5e:65:91:62 ip=lan0:auto6 ifname=mgmt0:b8:59:9f:1d:d8:e2 ip=mgmt0:dhcp ifname=mgmt1:b8:59:9f:1d:d8:e3 ip=mgmt1:auto6 psi=1 pcie_ports=native transparent_hugepage=never console=tty0 console=ttyS0,115200 iommu=pt metal.server=http://rgw-vip.nmn/boot-images/k8s/rusty/filesystem.squashfs?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=NUKSKGZGE1V32708BV04%2F20220809%2Fdefault%2Fs3%2Faws4_request&X-Amz-Date=20220809T193141Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=cdc6ff172cd35bb320a822d1dbd8ff87c8fae3e25be7cfd1a396f6ead240c01f metal.no-wipe=0 ds=nocloud-net;s=http://10.92.100.81:8888/ rootfallback=LABEL=BOOTRAID rd.live.dir=1.3.0-alpha.36 root=live:LABEL=SQFSRAID rd.live.ram=0 rd.writable.fsimg=0 rd.skipfsck rd.live.squashimg=filesystem.squashfs rd.live.overlay=LABEL=ROOTRAID rd.live.overlay.thin=1 rd.live.overlay.overlayfs=1 rd.luks=0 rd.luks.crypttab=0 rd.lvm.conf=0 rd.lvm=1 rd.auto=1 rd.md=1 rd.dm=0 rd.neednet=0 rd.peerdns=0 rd.md.waitclean=1 rd.multipath=0 rd.md.conf=1 rd.bootif=0 hostname=ncn-w003 rd.net.timeout.carrier=120 rd.net.timeout.ifup=120 rd.net.timeout.iflink=120 rd.net.dhcp.retry=5 rd.net.timeout.ipv6auto=0 rd.net.timeout.ipv6dad=0 append nosplash quiet crashkernel=360M log_buf_len=1 rd.retry=10 rd.shell rd.debug=1 xname=x3000c0s11b0n0 nid=100006 bss_referral_token=5a811a39-4ba2-4b80-94a3-8d559786b1cf
```

```bash
ncn-w003:~ # ls -l /run/initramfs/live/*
total 6437828
-rw-r--r-- 1 root root        712 Aug  9 19:32 download.stderr
-rw-r--r-- 1 root root          0 Aug  9 19:32 download.stdout
-rw-r--r-- 1 root root 6592331776 Aug  9 19:32 filesystem.squashfs
```

This is backwards compatible with non-pre-signed URLs for bootstrapping from the PIT node. Successful tests for backwards compatibility were carried out on redbull.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
