### PR TITLE
VSHA-536 Zero `md` Superblocks

### DIFF
--- a/90metalmdsquash/metal-genrules.sh
+++ b/90metalmdsquash/metal-genrules.sh
@@ -29,7 +29,7 @@ command -v getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 case "$(getarg root)" in 
     kdump)
-        /sbin/initqueue --settled /sbin/metal-md-scan
+        /sbin/initqueue --settled --onetime --unique /sbin/metal-md-scan
         
         # Ensure nothing else in this script is invoked in this case.
         exit 0
@@ -59,7 +59,7 @@ case "${metal_uri_scheme:-}" in
         ;;
     '')
         # Boot from block device.
-        /sbin/initqueue --settled /sbin/metal-md-scan
+        /sbin/initqueue --settled --onetime --unique /sbin/metal-md-scan
         ;;
     *)
         warn "Unknown driver $metal_server; metal.server ignored/discarded"

--- a/90metalmdsquash/metal-kdump.sh
+++ b/90metalmdsquash/metal-kdump.sh
@@ -33,8 +33,7 @@ command -v _overlayFS_path_spec > /dev/null 2>&1 || . /lib/metal-lib.sh
 
 case "$(getarg root)" in 
     kdump)
-        /sbin/initqueue --settled /sbin/metal-md-scan
-        
+
         # Ensure nothing else in this script is invoked in this case.
         exit 0
         ;;

--- a/90metalmdsquash/metal-lib.sh
+++ b/90metalmdsquash/metal-lib.sh
@@ -77,9 +77,25 @@ export METAL_LOG_DIR='/var/log/metal'
 mkdir -p $METAL_LOG_DIR
 
 ##############################################################################
+# constant: METAL_HASH
+# constant: METAL_DOCS_URL
+#
+# This is the VCS hash for commit that produced this library, it is auto-filled
+# when this module is built into an OS package.
+# This is useful for printing URLs to documentation that are relevant to the
+# library running in an initramFS.
+METAL_HASH='@@metal-hash@@'
+if [[ ${METAL_HASH} =~ 'metal-hash' ]]; then
+    # Default to main if this is running directly out of the repo.
+    METAL_HASH='main'
+fi
+export METAL_HASH
+export METAL_DOCS_URL=https://github.com/Cray-HPE/dracut-metal-mdsquash/tree/${METAL_HASH}
+
+##############################################################################
 # constant: METAL_DONE_FILE_PAVED
 #
-# This file path present a file that the wipe function creates when it is 
+# This file path present a file that the wipe function creates when it is
 # invoked. The existence of the file implies the wipe code as been invoked,
 # the contents of the file can be interpretted to determine what the wipe
 # function actually did (see func metal_paved).
@@ -169,7 +185,7 @@ metal_die() {
     fi
     type die
     echo >&2 "metal_die: $*"
-    echo >&2 "GitHub/Docs: https://github.com/Cray-HPE/dracut-metal-mdsquash"
+    echo >&2 "GitHub/Docs: ${METAL_DOCS_URL}/README.adoc"
     sleep 30 # Leaving time (30seconds) for console/log buffers to catch up.
     if [ "$_reset" = 1 ]; then
         

--- a/90metalmdsquash/metal-md-disks.sh
+++ b/90metalmdsquash/metal-md-disks.sh
@@ -65,7 +65,7 @@ if [ ! -f /tmp/metalsqfsdisk.done ] && [ "${metal_nowipe}" -eq 0 ]; then
         metal_die "No disks were found for the OS that were [$metal_disk_small] (in bytes) or larger, all were too small or had filesystems present!"
         exit 1
     else
-        echo >&2 "Found the following disks for the main RAID array (qty. [$metal_disks]): [${md_disks[*]}]"
+        echo >&2 "Found the following disk(s) for the main RAID array (qty. [$metal_disks]): [${md_disks[*]}]"
     fi
 fi
 

--- a/90metalmdsquash/metal-md-disks.sh
+++ b/90metalmdsquash/metal-md-disks.sh
@@ -39,11 +39,11 @@ disks_exist || exit 1
 # Now that disks exist it's worthwhile to load the libraries.
 command -v pave > /dev/null 2>&1 || . /lib/metal-md-lib.sh
 
-# Wipe; this returns early if a wipe was already done.
-pave
-
 # Check for existing RAIDs
 /sbin/metal-md-scan
+
+# Wipe; this returns early if a wipe was already done.
+pave
 
 # At this point this module is required; a disk must be created or the system has nothing to boot.
 # Die if no viable disks are found; otherwise continue to disk creation functions.

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ rpm_package_source:
 	tar --transform 'flags=r;s,^,/${NAME}-${VERSION}/,' --exclude .git --exclude dist -cvjf $(SOURCE_PATH) .
 
 rpm_build_source:
-	BUILD_METADATA=$(BUILD_METADATA) rpmbuild --nodeps -ts $(SOURCE_PATH) --define "_topdir $(BUILD_DIR)"
+	rpmbuild --nodeps -ts $(SOURCE_PATH) --define "_topdir $(BUILD_DIR)"
 
 rpm_build:
-	BUILD_METADATA=$(BUILD_METADATA) rpmbuild --nodeps -ba $(SPEC_FILE) --define "_topdir $(BUILD_DIR)"
+	rpmbuild --nodeps -ba $(SPEC_FILE) --define "_topdir $(BUILD_DIR)"

--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,7 @@ In order to use this dracut module, you need:
 
 . A local-attached-usb or remote server with a squashFS image.
 . Physical block devices must be installed in your blade(s).
-. Two physical disk of 0.5TiB or less (or the RAID must be overridden, see <<metal-mdsquash-customizations,metal mdsquash customization>>
+. Two physical disk of 0.5TiB or less (or the RAID must be overridden, see <<_metal-mdsquash-customizations,metal mdsquash customization>>
 
 == Usage
 
@@ -30,7 +30,7 @@ metal.server=<URI> root=live:LABEL=SQFSRAID
 ----
 
 The above snippet is the minimal cmdline necessary for this module to function. Additional options
-are denoted throughout the <<parameters,module customization>> section.
+are denoted throughout the <<_kernel_parameters,module customization>> section.
 
 == URI Drivers
 
@@ -60,28 +60,32 @@ http://10.100.101.111/some/local/server
 
 Other drivers, such as native `s3`, `scp`, and `ftp` could be added but are not currently implemented.
 
-These drivers schemes are all defined by the rule generator, link:./90metalmdsquash/metal-genrules.sh[`metal-genrules.sh`].
+These drivers schemes are all defined by the rule generator, link:./90metalmdsquash/metal-genrules.sh[`metal-genrules.sh`^].
 
+[#_kernel_parameters]
 == Kernel Parameters
 
+[#_metal-mdsquash-customizations]
 === metal-mdsquash customizations
 
 ==== `metal.debug`
 
-Set `metal.debug=1` to enable debug output from only metal modules. This will verbosely print the creation of the RAIDs and fetching of the squashFS image. *This effectively runs all dracut-metal code with `set -x`*, while leaving the rest of dracut to its own debug level.
+Set `metal.debug=1` to enable debug output from only metal modules.This will verbosely print the creation of the RAIDs and fetching of the squashFS image. *This effectively runs all dracut-metal code with `set -x`*, while leaving the rest of dracut to its own debug level.
 
 - `Default: 0`
 
 ==== `metal.disks`
 
-Specify the number of disks to use in the local RAID (see link:README.md#metalmd-level[`metal.md-level`] for changing the RAID type).
+Specify the number of disks to use in the local RAID (see <<_metal_md_level>> for changing the RAID type).
 
 - `Default: 2`
 
+[#_metal_md_level]
 ==== `metal.md-level`
 
 Change the level passed to mdadm for RAID creation, possible values are any value it takes.
 Milaege varies, buyer beware this could dig a hole deeper.
+
 - `Default: mirror`
 
 NOTE: When `metal.disks=1` is set, a RAID array is still created but with only one member.
@@ -89,20 +93,98 @@ In this case, only mirror and stripe will produce
 
 ==== `metal.no-wipe`
 
-If this is set to `metal.no-wipe=1`, then all destructive behavior is disabled. The metal modules will either use what they find or make 0 changes during boots. This is insurance, it should not be required. This is helpful for development, or for admins tracking old and new nodes.
+Determines if the wipe function should run, `metal.no-wipe=0` will wipe block devices and make them ready for partitioning. `metal.no-wipe=1`
+will disable this behavior.
+
 - `Default: 0`
 
+.Note that a warning will print with a timeout in which the user may power the node `off` to avoid a wipe. This timeout can be adjusted, see <<_metal_wipe_delay>>.
+
+The following storage items are removed and/or prepared for partitioning as a raw disk:
+
+. LVMs (specifically `'vg_name=~ceph*' and 'vg_name=~metal*'`)
+** This removes any CEPH volumes
+** Any volume prefixed with `metal` is considered a relative to this module and will be removed
+* Volumes are removed with `vgremove`
+. `/dev/md` devices
+** MD Devices are stopped
+** Magic bits erased
+** Each memeber's superblocks are zeroed
+. `/dev/sd` and `/dev/nvme` devices
+** Magic bits erased
+. Any/all USB devices are ignored
+. Any/all devices smaller than `metal.min-disk-size*1024**3 bytes` is ignored (see <<_metal_min_disk_size>>)
+. `partprobe` is invoked to update/notify the kernel of the partition changes
+. Any LVMs that weren't on a device that was wiped will still exist, since only specific LVMs are targeted
+
+.Example output of a wipe running
+[source,text]
+----
+Warning: local storage device wipe [ safeguard: DISABLED ]
+Warning: local storage devices WILL be wiped (https://github.com/Cray-HPE/dracut-metal-mdsquash/tree/7d303b3193619f642b1316ce2b1968ee1cc82a69#metalno-wipe)
+Warning: local storage device wipe commencing ...
+Warning: local storage device wipe ignores USB devices and block devices less then or equal to [17179869184] bytes.
+Warning: nothing can be done to stop this except one one thing ...
+Warning: power this node off within the next [5] seconds to cancel.
+Warning: NOTE: this delay can be adjusted, see: https://github.com/Cray-HPE/dracut-metal-mdsquash/tree/7d303b3193619f642b1316ce2b1968ee1cc82a69#metalwipe-delay)
+  Found volume group "metalvg0" using metadata type lvm2
+  Found volume group "ceph-ec4a2c46-e0ab-4f89-b7dc-6c044ce9a24b" using metadata type lvm2
+  Found volume group "ceph-2c5c9402-7bc2-4a8c-8eba-028532b91d9f" using metadata type lvm2
+  Found volume group "ceph-a38bb9f7-99ef-4536-82cf-2550a406da38" using metadata type lvm2
+  Found volume group "ceph-c1e6018e-6a50-4b17-a15d-b387ae66b8a4" using metadata type lvm2
+  VG                                        #PV #LV #SN Attr   VSize    VFree
+  ceph-2c5c9402-7bc2-4a8c-8eba-028532b91d9f   1   1   0 wz--n-   <1.75t      0
+  ceph-a38bb9f7-99ef-4536-82cf-2550a406da38   1   1   0 wz--n-   <1.75t      0
+  ceph-c1e6018e-6a50-4b17-a15d-b387ae66b8a4   1   1   0 wz--n- <447.13g      0
+  ceph-ec4a2c46-e0ab-4f89-b7dc-6c044ce9a24b   1   1   0 wz--n-   <1.75t      0
+  metalvg0                                    1   3   0 wz--n-  279.14g 149.14g
+Warning: removing all volume groups of name [vg_name=~ceph*]
+  Failed to clear hint file.
+  Logical volume "osd-block-a8c05059-d921-4546-884d-f63f606f966c" successfully removed
+  Volume group "ceph-ec4a2c46-e0ab-4f89-b7dc-6c044ce9a24b" successfully removed
+  Logical volume "osd-block-d70a9ddd-9b8c-42e0-98cb-5f5279dcef5a" successfully removed
+  Volume group "ceph-2c5c9402-7bc2-4a8c-8eba-028532b91d9f" successfully removed
+  Logical volume "osd-block-d2e9e4cf-c670-418f-847e-39ade3208d04" successfully removed
+  Volume group "ceph-a38bb9f7-99ef-4536-82cf-2550a406da38" successfully removed
+  Logical volume "osd-block-b6085667-54dc-4e01-810b-25c093a510dc" successfully removed
+  Volume group "ceph-c1e6018e-6a50-4b17-a15d-b387ae66b8a4" successfully removed
+Warning: removing all volume groups of name [vg_name=~metal*]
+  Failed to clear hint file.
+  Logical volume "CEPHETC" successfully removed
+  Logical volume "CEPHVAR" successfully removed
+  Logical volume "CONTAIN" successfully removed
+  Volume group "metalvg0" successfully removed
+Warning: local storage device wipe is targeting the following RAID(s): [/dev/md124 /dev/md125 /dev/md126 /dev/md127]
+Warning: local storage device wipe is targeting the following block devices: [/dev/sda /dev/sdb /dev/sdc /dev/sdd /dev/sde /dev/sdf]
+Warning: local storage disk wipe complete
+Found the following disks for the main RAID array (qty. [2]): [sda sdb]
+mdadm: size set to 487360K
+mdadm: array /dev/md/BOOT started.
+mdadm: size set to 23908352K
+mdadm: array /dev/md/SQFS started.
+mdadm: size set to 146352128K
+mdadm: automatically enabling write-intent bitmap on large array
+mdadm: array /dev/md/ROOT started.
+mdadm: chunk size defaults to 512K
+mdadm: array /dev/md/AUX started.
+----
+
+[#_metal_wipe_delay]
 ==== `metal.wipe-delay`
 
-The number of seconds that the wipe function will wait to allow an administrator to cancel it (by powering the node off). See the source code in link:./90metalmdsquash/metal-md-lib.sh[`metal-md-lib.sh`] for minimum and maximum values.
+The number of seconds that the wipe function will wait to allow an administrator to cancel it (by powering the node off).See the source code in link:./90metalmdsquash/metal-md-lib.sh[`metal-md-lib.sh`] for minimum and maximum values.
 
 - `Default: 5`
 - `Unit: Seconds`
 
 ==== `metal.ipv4`
 
-By default, metal-dracut will use IPv4 to resolve the deployment server for the initial call-to-home and when downloading artifacts regardless if IPv6 networking is present in the environment. To disable this constraint, simply set `metal.ipv4=0` in the cmdline. Setting this to `0` will enable all `ping` and `curl` calls for calling-home and downloading artifacts to use *either* IPv6 or IPv4 on their own accord (e.g. if IPv6 exists, then `ping` and `curl` will prefer to use it by default). Presumably if IPv6 is desired and exists, then IPv6 DHCP/DNS and general TCP/IP connectivity is working.
-Lastly, if IPv6 does not exist then toggling this value to `0` has no effect.
+By default, metal-dracut will use IPv4 to resolve the deployment server for the initial call-to-home and when downloading artifacts regardless if IPv6 networking is present in the environment.
+This is to safeguard against fault/misconfigured IPv6 environments.
+
+To disable this constraint, simply set `metal.ipv4=0` in the cmdline. Setting `0` will
+enable IPv6 for this module.
+
 - `Default: 1`
 
 ==== `metal.sqfs-md-size`
@@ -129,16 +211,19 @@ Buyer beware this does not resize, this applies for new partitions.
 - `Default: 150`
 - `Unit: Gigabytes`
 
+[#_metal_min_disk_size]
 ==== `metal.min-disk-size`
 
-Sets the minimum size threshold when wiping and partitioning disks, anything `&lt;` this left untouched.
+Sets the minimum size threshold when wiping and partitioning disks, anything less than or equal is this left untouched.
 
 - `Default: 16`
 - `Unit: Gigabytes`
 
+The value is converted to bytes (`metal.min-disk-size*1024**3`), all comparisons are done in this unit.
+
 === dmsquashlive customizations
 
-reference: https://github.com/dracutdevs/dracut/blob/master/dracut.cmdline.7.asc#booting-live-images[dracut dmsquashlive cmdline]
+reference: https://github.com/dracutdevs/dracut/blob/master/man/dracut.cmdline.7.asc#booting-live-images[dracut dmsquashlive cmdline^]
 
 ==== `rd.live.dir`
 
@@ -158,7 +243,7 @@ Can also be of UUID or
 
 Specify the FSlabel of the block device to use for persistent storage.
 If a label is not found in `/dev/disk/by-label/*`, then the os-disks are paved.
-If this is specified, then rd.live.overlay=$newlabel must also be specified.
+If this is specified, then `rd.live.overlay=LABEL=<new_label_here>` must also be specified.
 
 - `Default: LABEL=ROOTRAID`
 
@@ -191,7 +276,7 @@ Specify the filename to refer to download.
 
 === dracut : standard customizations
 
-reference: https://github.com/dracutdevs/dracut/blob/master/dracut.cmdline.7.asc#standard[dracut standard cmdline]
+reference: https://github.com/dracutdevs/dracut/blob/master/man/dracut.cmdline.7.asc#standard[dracut standard cmdline^]
 
 ==== `rootfallback`
 
@@ -207,41 +292,5 @@ The idea of persistence is that changes _persist_ across reboots, when the state
 changes it preserves information. For servers that boot images into memory (also known as live images),
 an overlayFS is a common method for providing persistent storage.
 
-=== Feature Toggles
-
-Metal squashFS URL Dracut module has a few feature toggles, by default it is recommended to leave
-them alone unless you must change them for your environment.
-
-==== Toggling Persistence
-
-Disable the overlayFS entirely by setting `rd.live.overlay=0`, this will cause a temporary overlay
-to be created that exists in memory. A prompt may appear during boot to acknowledge the RAM overlayFS.
-
-To disable it entirely, delete all `rd.live.overlay.*` options.
-
-==== Toggling Read-Only OverlayFS
-
-Setting `rd.live.readonly=1` will cause the next boot's persistent overlayFS to be mounted
-as read-only. This has a different convention in overlayFS and will look differently on your
-system pending certain toggles:
-
-* either an
- additional, non-persistent, writable snapshot overlay will be
- stacked over a read-only snapshot, /dev/mapper/live-ro, of the
- base filesystem with the persistent overlay,
-* or a read-only loop
- device, in the case of a writable rootfs.img,
-* *(default)* or an OverlayFS
- mount will use the persistent overlay directory linked at
- /run/overlayfs-r as an additional lower layer along with the base
- root filesystem and apply a transient, writable upper directory
- overlay, in order to complete the booted root filesystem.
-
-==== Toggling Resetting the Persistent OverlayFS on Boot
-
-To cleanly reset the overlayFS, reboot the node with this kernel option:
-`rd.live.overlay.reset=1`.
-
-The OverlayFS is reset by recreating the image file if it doesn't exist, and then by wiping the image
-file if it does exist. The wipe is controlled by dracut-native (dmsquash-live), the creation of
-the image file is handled by this dracut module (metal-squashfs-url-dracut).
+The overlayFS created by this dracut module is used by the dmsquash-live module, all dracut live image
+kernel parameters should function alongside this module.

--- a/dracut-metal-mdsquash.spec
+++ b/dracut-metal-mdsquash.spec
@@ -60,6 +60,11 @@ Provides: %{module_name}
 %setup -q
 
 %build
+%define hash %(git rev-parse --verify HEAD)
+if [ -n %{hash} ]; then
+    echo %{hash}
+sed -i 's,@@metal-hash@@,%{hash},g' %{module_name}/metal-lib.sh
+fi
 
 %install
 %{__mkdir_p} %{buildroot}%{url_dracut_doc}


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: #56 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
This change ensures the RAIDs are eradicated and made unrecognizable by erasing their superblocks in order to resolve sync timing problems between Vshasta and metal. 

The new logic explicitly stops the `md` devices, wipes their magic bits, and then eradicates the `md` superblocks on each disk.

During testing of VSHA-536 there was some fiddling with how the RAIDs were wiped to account for some peculiarities with the timings of how `virtio` synced and updated the kernel. The changes had been tested on metal without any observed problems, but in my recent series of tests some fatal inconsistencies were observed. The `partprobe` was revealing `md` handles, this caused `mdadm` to restart/resume RAIDs that had been "nuked" and this in turn caused partitioning to fail.

This change also includes some minor fixes:
- The `wipefs` command for sd/nvme devices was not getting piped to the log file.
- The info printed when manually sourcing `/lib/metal-md-lib.sh` in a dracut shell is now left justified and aligned by colon.
- The extra `/sbin/metal-md-scan` call in `/sbin/metal-md-disks` is removed, it is no longer important shouldn't be invoked every loop that calls `/sbin/metal-md-disks`.
- `metal-kdump.sh` no longer invokes `/sbin/metal-md-scan` under `root=kdump` because that script is already invoked by the initqueue (see `metal-genrules.sh`)
- All initqueue calls to `metal-md-scan` have been changed to `--unique` and `--onetime` to ensure they never have an opportunity to run forever (as witnessed during a kdump test of the LiveCD)

A note about the dependency on `mdraid-cleanup`:

It turns out relying on `mdraid-cleanup` was a bad idea. The `mdraid-cleanup` script only stops RAIDs, it does not remove any superblock (or remove the RAIDs for that matter). This means that there is a (small) possibility that the RAID and its members still exist when the `partprobe` command fires. The window of time that this issue can occur is very small, and varies. VShasta has not hit this error in the 10-20 deployments it has done in the past 3-4 days, my 50+ boots I tested didn't hit this, but the past 10 NCN boots I just attempted hit this almost every time.


### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
