### PR TITLE
MTL-2272: remove xfs options; use defaults

### DIFF
--- a/90metalmdsquash/metal-lib.sh
+++ b/90metalmdsquash/metal-lib.sh
@@ -128,7 +128,7 @@ export metal_fstab=/etc/fstab.metal
 # constant: metal_fsopts_xfs
 #
 # COMMA-DELIMITED-LIST of fsopts for XFS
-export metal_fsopts_xfs=noatime,largeio,inode64,swalloc,allocsize=131072k
+export metal_fsopts_xfs=
 
 ##############################################################################
 # constant: metal_disk_small


### PR DESCRIPTION
### Summary and Scope

It was discovered that allocsize, in particular, was causing problems during IMS image builds. The db files for the 'man' package were being forced to a size that was much larger than what was needed, both wasting space and causing build times to be significantly increased.


<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2272

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
