### PR TITLE
MTL-2363: fix "one one" typo

### DIFF
--- a/90metalmdsquash/metal-md-lib.sh
+++ b/90metalmdsquash/metal-md-lib.sh
@@ -371,7 +371,7 @@ pave() {
     warn 'local storage device wipe commencing ...'
     warn "local storage device wipe ignores USB devices and block devices smaller than [$metal_ignore_threshold] bytes."
 
-    warn 'nothing can be done to stop this except one one thing ...'
+    warn 'nothing can be done to stop this except one thing ...'
     warn "power this node off within the next [$metal_wipe_delay] second(s) to cancel."
     warn "NOTE: this delay can be adjusted, see: ${METAL_DOCS_URL}#metalwipe-delay"
     while [ "${metal_wipe_delay}" -ge 0 ]; do


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2363

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
